### PR TITLE
SQLite DB for tesing

### DIFF
--- a/src/CookBook/CookBook.App/App.xaml.cs
+++ b/src/CookBook/CookBook.App/App.xaml.cs
@@ -55,7 +55,7 @@ namespace CookBook.App
             services.AddSingleton<IDbContextFactory<CookBookDbContext>>(provider =>
             {
                 var dalSettings = provider.GetRequiredService<IOptions<DALSettings>>().Value;
-                return new SqlServerDbContextFactory(dalSettings.ConnectionString!, dalSettings.SkipMigrationAndSeedTestingData);
+                return new SqlServerDbContextFactory(dalSettings.ConnectionString!, dalSettings.SkipMigrationAndSeedDemoData);
             });
 
             services.AddSingleton<MainWindow>();
@@ -81,8 +81,9 @@ namespace CookBook.App
             
             await using (var dbx = await dbContextFactory.CreateDbContextAsync())
             {
-                if (dalSettings.SkipMigrationAndSeedTestingData)
+                if (dalSettings.SkipMigrationAndSeedDemoData)
                 {
+                    await dbx.Database.EnsureDeletedAsync();
                     await dbx.Database.EnsureCreatedAsync();
                 }
                 else

--- a/src/CookBook/CookBook.App/AppSettings.json
+++ b/src/CookBook/CookBook.App/AppSettings.json
@@ -2,7 +2,7 @@
   "CookBook" : {
     "DAL": {
       "ConnectionString": "Data Source=(LocalDB)\\MSSQLLocalDB;Initial Catalog = CookBook;MultipleActiveResultSets = True;Integrated Security = True; ",
-      "SkipMigrationAndSeedTestingData" :  true 
+      "SkipMigrationAndSeedDemoData" :  true 
     }
   } 
 }

--- a/src/CookBook/CookBook.App/Settings/DALSettings.cs
+++ b/src/CookBook/CookBook.App/Settings/DALSettings.cs
@@ -9,6 +9,6 @@ namespace CookBook.App.Settings
     public class DALSettings
     {
         public string? ConnectionString { get; set; }
-        public bool SkipMigrationAndSeedTestingData { get; set; }
+        public bool SkipMigrationAndSeedDemoData { get; set; }
     }
 }

--- a/src/CookBook/CookBook.BL.Tests/CRUDFacadeTestsBase.cs
+++ b/src/CookBook/CookBook.BL.Tests/CRUDFacadeTestsBase.cs
@@ -20,8 +20,8 @@ public class  CRUDFacadeTestsBase : IAsyncLifetime
         XUnitTestOutputConverter converter = new(output);
         Console.SetOut(converter);
 
-        //DbContextFactory = new DbContextInMemoryFactory(GetType().Name, seedTestingData: true);
-        DbContextFactory = new DbContextLocalDBTestingFactory(GetType().FullName!, seedTestingData: true);
+        DbContextFactory = new DbContextTestingInMemoryFactory(GetType().Name, seedTestingData: true);
+        // DbContextFactory = new DbContextLocalDBTestingFactory(GetType().FullName!, seedTestingData: true);
 
         UnitOfWorkFactory = new UnitOfWorkFactory(DbContextFactory);
 
@@ -50,6 +50,7 @@ public class  CRUDFacadeTestsBase : IAsyncLifetime
     public async Task InitializeAsync()
     {
         await using var dbx = await DbContextFactory.CreateDbContextAsync();
+        await dbx.Database.EnsureDeletedAsync();
         await dbx.Database.EnsureCreatedAsync();
     }
 

--- a/src/CookBook/CookBook.BL.Tests/CRUDFacadeTestsBase.cs
+++ b/src/CookBook/CookBook.BL.Tests/CRUDFacadeTestsBase.cs
@@ -20,8 +20,9 @@ public class  CRUDFacadeTestsBase : IAsyncLifetime
         XUnitTestOutputConverter converter = new(output);
         Console.SetOut(converter);
 
-        DbContextFactory = new DbContextTestingInMemoryFactory(GetType().Name, seedTestingData: true);
+        // DbContextFactory = new DbContextTestingInMemoryFactory(GetType().Name, seedTestingData: true);
         // DbContextFactory = new DbContextLocalDBTestingFactory(GetType().FullName!, seedTestingData: true);
+        DbContextFactory = new DbContextSQLiteTestingFactory(GetType().FullName!, seedTestingData: true);
 
         UnitOfWorkFactory = new UnitOfWorkFactory(DbContextFactory);
 

--- a/src/CookBook/CookBook.BL.Tests/IngredientFacadeTests.cs
+++ b/src/CookBook/CookBook.BL.Tests/IngredientFacadeTests.cs
@@ -1,13 +1,9 @@
 ﻿using CookBook.BL.Models;
-using CookBook.DAL;
-using CookBook.DAL.Factories;
-using CookBook.DAL.Seeds;
-using System;
 using System.Linq;
 using System.Threading.Tasks;
 using CookBook.BL.Facades;
 using CookBook.Common.Tests;
-using CookBook.DAL.Entities;
+using CookBook.Common.Tests.Seeds;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
 using Xunit.Abstractions;

--- a/src/CookBook/CookBook.BL.Tests/RecipeFacadeTests.cs
+++ b/src/CookBook/CookBook.BL.Tests/RecipeFacadeTests.cs
@@ -1,14 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using CookBook.BL.Facades;
 using CookBook.BL.Models;
 using CookBook.Common.Enums;
 using CookBook.Common.Tests;
-using CookBook.DAL;
-using CookBook.DAL.Factories;
-using CookBook.DAL.Seeds;
+using CookBook.Common.Tests.Seeds;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
 using Xunit.Abstractions;

--- a/src/CookBook/CookBook.Common.Tests/CookBook.Common.Tests.csproj
+++ b/src/CookBook/CookBook.Common.Tests/CookBook.Common.Tests.csproj
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.75.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.2" />
     <PackageReference Include="xunit.assert" Version="2.4.1" />
     <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
   </ItemGroup>

--- a/src/CookBook/CookBook.Common.Tests/CookBookTestingDbContext.cs
+++ b/src/CookBook/CookBook.Common.Tests/CookBookTestingDbContext.cs
@@ -1,0 +1,29 @@
+﻿using CookBook.Common.Tests.Seeds;
+using CookBook.DAL;
+using Microsoft.EntityFrameworkCore;
+
+namespace CookBook.Common.Tests
+{
+    public class CookBookTestingDbContext : CookBookDbContext
+    {
+        private readonly bool _seedTestingData;
+
+        public CookBookTestingDbContext(DbContextOptions contextOptions, bool seedTestingData = false)
+            : base(contextOptions, seedDemoData:false)
+        {
+            _seedTestingData = seedTestingData;
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            if (_seedTestingData)
+            {
+                IngredientSeeds.Seed(modelBuilder);
+                RecipeSeeds.Seed(modelBuilder);
+                IngredientAmountSeeds.Seed(modelBuilder);
+            }
+        }
+    }
+}

--- a/src/CookBook/CookBook.Common.Tests/Factories/DbContextLocalDBTestingFactory.cs
+++ b/src/CookBook/CookBook.Common.Tests/Factories/DbContextLocalDBTestingFactory.cs
@@ -21,6 +21,6 @@ public class DbContextLocalDBTestingFactory : IDbContextFactory<CookBookDbContex
         // contextOptionsBuilder.LogTo(System.Console.WriteLine); //Enable in case you want to see tests details, enabled may cause some inconsistencies in tests
         // builder.EnableSensitiveDataLogging();
         
-        return new CookBookDbContext(builder.Options, _seedTestingData);
+        return new CookBookTestingDbContext(builder.Options, _seedTestingData);
     }
 }

--- a/src/CookBook/CookBook.Common.Tests/Factories/DbContextSQLiteTestingFactory.cs
+++ b/src/CookBook/CookBook.Common.Tests/Factories/DbContextSQLiteTestingFactory.cs
@@ -1,0 +1,26 @@
+﻿using CookBook.DAL;
+using Microsoft.EntityFrameworkCore;
+
+namespace CookBook.Common.Tests.Factories;
+
+public class DbContextSQLiteTestingFactory : IDbContextFactory<CookBookDbContext>
+{
+    private readonly string _databaseName;
+    private readonly bool _seedTestingData;
+
+    public DbContextSQLiteTestingFactory(string databaseName, bool seedTestingData = false)
+    {
+        _databaseName = databaseName;
+        _seedTestingData = seedTestingData;
+    }
+    public CookBookDbContext CreateDbContext()
+    {
+        DbContextOptionsBuilder<CookBookDbContext> builder = new();
+        builder.UseSqlite($"Data Source={_databaseName};Cache=Shared");
+        
+        // contextOptionsBuilder.LogTo(System.Console.WriteLine); //Enable in case you want to see tests details, enabled may cause some inconsistencies in tests
+        // builder.EnableSensitiveDataLogging();
+        
+        return new CookBookTestingDbContext(builder.Options, _seedTestingData);
+    }
+}

--- a/src/CookBook/CookBook.Common.Tests/Factories/DbContextTestingInMemoryFactory.cs
+++ b/src/CookBook/CookBook.Common.Tests/Factories/DbContextTestingInMemoryFactory.cs
@@ -4,12 +4,12 @@ using Microsoft.EntityFrameworkCore;
 
 namespace CookBook.Common.Tests.Factories
 {
-    public class DbContextInMemoryFactory: IDbContextFactory<CookBookDbContext>
+    public class DbContextTestingInMemoryFactory: IDbContextFactory<CookBookDbContext>
     {
         private readonly string _databaseName;
         private readonly bool _seedTestingData;
 
-        public DbContextInMemoryFactory(string databaseName, bool seedTestingData = false)
+        public DbContextTestingInMemoryFactory(string databaseName, bool seedTestingData = false)
         {
             _databaseName = databaseName;
             _seedTestingData = seedTestingData;
@@ -23,7 +23,7 @@ namespace CookBook.Common.Tests.Factories
             // contextOptionsBuilder.LogTo(System.Console.WriteLine); //Enable in case you want to see tests details, enabled may cause some inconsistencies in tests
             // builder.EnableSensitiveDataLogging();
             
-            return new CookBookDbContext(contextOptionsBuilder.Options, _seedTestingData);
+            return new CookBookTestingDbContext(contextOptionsBuilder.Options, _seedTestingData);
         }
     }
 }

--- a/src/CookBook/CookBook.Common.Tests/Seeds/IngredientAmountSeeds.cs
+++ b/src/CookBook/CookBook.Common.Tests/Seeds/IngredientAmountSeeds.cs
@@ -1,0 +1,55 @@
+﻿using CookBook.Common.Enums;
+using CookBook.DAL.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace CookBook.Common.Tests.Seeds;
+
+public static class IngredientAmountSeeds
+{
+    public static readonly IngredientAmountEntity EmptyIngredientAmountEntity = new(
+        Id: default, 
+        Amount: default,
+        Unit: default,
+        RecipeId: default, 
+        IngredientId: default)
+    {
+        Recipe = default,
+        Ingredient = default
+    };
+    
+    public static readonly IngredientAmountEntity IngredientAmountEntity1 = new(
+        Id: Guid.Parse(input: "0d4fa150-ad80-4d46-a511-4c666166ec5e"),
+        Amount: 1.0,
+        Unit: Unit.Kg,
+        RecipeId: RecipeSeeds.RecipeEntity.Id,
+        IngredientId: IngredientSeeds.IngredientEntity1.Id)
+    {
+        Recipe = RecipeSeeds.RecipeEntity,
+        Ingredient = IngredientSeeds.IngredientEntity1
+    };
+
+    public static readonly IngredientAmountEntity IngredientAmountEntity2 = new(
+        Id: Guid.Parse(input: "87833e66-05ba-4d6b-900b-fe5ace88dbd8"),
+        Amount: 2.0,
+        Unit: Unit.L,
+        RecipeId: RecipeSeeds.RecipeEntity.Id,
+        IngredientId: IngredientSeeds.IngredientEntity2.Id)
+    {
+        Recipe = RecipeSeeds.RecipeEntity,
+        Ingredient = IngredientSeeds.IngredientEntity2
+    };
+
+    //To ensure that no tests reuse these clones for non-idempotent operations
+    public static readonly IngredientAmountEntity IngredientAmountEntityUpdate = IngredientAmountEntity1 with { Id = Guid.Parse("A2E6849D-A158-4436-980C-7FC26B60C674"), Ingredient = null, Recipe = null, RecipeId = RecipeSeeds.RecipeForIngredientAmountEntityUpdate.Id};
+    public static readonly IngredientAmountEntity IngredientAmountEntityDelete = IngredientAmountEntity1 with { Id = Guid.Parse("30872EFF-CED4-4F2B-89DB-0EE83A74D279"), Ingredient = null, Recipe = null, RecipeId = RecipeSeeds.RecipeForIngredientAmountEntityDelete.Id };
+
+    public static void Seed(this ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<IngredientAmountEntity>().HasData(
+            IngredientAmountEntity1 with { Recipe = null, Ingredient = null },
+            IngredientAmountEntity2 with { Recipe = null, Ingredient = null },
+            IngredientAmountEntityUpdate,
+            IngredientAmountEntityDelete
+        );
+    }
+}

--- a/src/CookBook/CookBook.Common.Tests/Seeds/IngredientSeeds.cs
+++ b/src/CookBook/CookBook.Common.Tests/Seeds/IngredientSeeds.cs
@@ -1,0 +1,45 @@
+﻿using CookBook.DAL.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace CookBook.Common.Tests.Seeds;
+
+public static class IngredientSeeds
+{
+    public static readonly IngredientEntity EmptyIngredient = new(
+        Id: default,
+        Name: default!,
+        Description: default!,
+        ImageUrl: default!);
+    
+    public static readonly IngredientEntity Water = new(
+        Id: Guid.Parse(input: "06a8a2cf-ea03-4095-a3e4-aa0291fe9c75"),
+        Name: "Water",
+        Description: "Mineral water",
+        ImageUrl: "https://www.pngitem.com/pimgs/m/40-406527_cartoon-glass-of-water-png-glass-of-water.png");
+
+    //To ensure that no tests reuse these clones for non-idempotent operations
+    public static readonly IngredientEntity WaterUpdate = Water with { Id = Guid.Parse("143332B9-080E-4953-AEA5-BEF64679B052") };
+    public static readonly IngredientEntity WaterDelete = Water with { Id = Guid.Parse("274D0CC9-A948-4818-AADB-A8B4C0506619") };
+
+    public static IngredientEntity IngredientEntity1 = new(
+        Id: Guid.Parse(input: "df935095-8709-4040-a2bb-b6f97cb416dc"),
+        Name: "Ingredient seeded ingredient 1",
+        Description: "Ingredient seeded ingredient 1 description",
+        ImageUrl: null);
+
+    public static IngredientEntity IngredientEntity2 = new(
+        Id: Guid.Parse(input: "23b3902d-7d4f-4213-9cf0-112348f56238"),
+        Name: "Ingredient seeded ingredient 2",
+        Description: "Ingredient seeded ingredient 2 description",
+        ImageUrl: null);
+
+    public static void Seed(this ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<IngredientEntity>().HasData(
+            IngredientEntity1,
+            IngredientEntity2,
+            Water,
+            WaterUpdate,
+            WaterDelete);
+    }
+}

--- a/src/CookBook/CookBook.Common.Tests/Seeds/RecipeSeeds.cs
+++ b/src/CookBook/CookBook.Common.Tests/Seeds/RecipeSeeds.cs
@@ -1,0 +1,51 @@
+﻿using CookBook.Common.Enums;
+using CookBook.DAL.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace CookBook.Common.Tests.Seeds;
+
+public static class RecipeSeeds
+{
+    public static readonly RecipeEntity EmptyRecipeEntity = new(
+        Id: default, 
+        Name: default!,
+        Description: default!,
+        Duration: default,
+        FoodType: default,
+        ImageUrl: default);
+    
+    public static readonly RecipeEntity RecipeEntity = new(
+        Id: Guid.Parse(input: "fabde0cd-eefe-443f-baf6-3d96cc2cbf2e"),
+        Name: "Recipe seeded recipe 1",
+        Description: "Recipe seeded recipe 1 description",
+        Duration: TimeSpan.FromHours(value: 2),
+        FoodType: FoodType.MainDish,
+        ImageUrl: null);
+
+    //To ensure that no tests reuse these clones for non-idempotent operations
+    public static readonly RecipeEntity RecipeEntityWithNoIngredients = RecipeEntity with { Id = Guid.Parse("98B7F7B6-0F51-43B3-B8C0-B5FCFFF6DC2E"), Ingredients = Array.Empty<IngredientAmountEntity>() };
+    public static readonly RecipeEntity RecipeEntityUpdate = RecipeEntity with { Id = Guid.Parse("0953F3CE-7B1A-48C1-9796-D2BAC7F67868"), Ingredients = Array.Empty<IngredientAmountEntity>() };
+    public static readonly RecipeEntity RecipeEntityDelete = RecipeEntity with { Id = Guid.Parse("5DCA4CEA-B8A8-4C86-A0B3-FFB78FBA1A09"), Ingredients = Array.Empty<IngredientAmountEntity>() };
+
+    public static readonly RecipeEntity RecipeForIngredientAmountEntityUpdate = RecipeEntity with { Id = Guid.Parse("4FD824C0-A7D1-48BA-8E7C-4F136CF8BF31"), Ingredients = Array.Empty<IngredientAmountEntity>() };
+    public static readonly RecipeEntity RecipeForIngredientAmountEntityDelete = RecipeEntity with { Id = Guid.Parse("F78ED923-E094-4016-9045-3F5BB7F2EB88"), Ingredients = Array.Empty<IngredientAmountEntity>() };
+
+
+    static RecipeSeeds()
+    {
+        RecipeEntity.Ingredients.Add(IngredientAmountSeeds.IngredientAmountEntity1);
+        RecipeEntity.Ingredients.Add(IngredientAmountSeeds.IngredientAmountEntity2);
+    }
+
+    public static void Seed(this ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<RecipeEntity>().HasData(
+            RecipeEntity with { Ingredients = Array.Empty<IngredientAmountEntity>() },
+            RecipeEntityWithNoIngredients,
+            RecipeEntityUpdate,
+            RecipeEntityDelete,
+            RecipeForIngredientAmountEntityUpdate,
+            RecipeForIngredientAmountEntityDelete
+        );
+    }
+}

--- a/src/CookBook/CookBook.Common/Enums/FoodType.cs
+++ b/src/CookBook/CookBook.Common/Enums/FoodType.cs
@@ -5,6 +5,7 @@
         None = 0,
         MainDish = 1,
         Soup = 2,
-        Dessert = 3
+        Dessert = 3,
+        Drink = 4
     }
 }

--- a/src/CookBook/CookBook.DAL.Tests/DbContextIngredientAmountTests.cs
+++ b/src/CookBook/CookBook.DAL.Tests/DbContextIngredientAmountTests.cs
@@ -1,13 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.InteropServices.ComTypes;
-using System.Text;
+﻿using System.Linq;
 using System.Threading.Tasks;
 using CookBook.Common.Enums;
-using CookBook.Common.Tests;
-using CookBook.DAL.Entities;
-using CookBook.DAL.Seeds;
+using CookBook.Common.Tests.Seeds;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
 using Xunit.Abstractions;

--- a/src/CookBook/CookBook.DAL.Tests/DbContextIngredientTests.cs
+++ b/src/CookBook/CookBook.DAL.Tests/DbContextIngredientTests.cs
@@ -1,13 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices.ComTypes;
-using System.Text;
 using System.Threading.Tasks;
-using CookBook.Common.Tests;
+using CookBook.Common.Tests.Seeds;
 using CookBook.DAL.Entities;
-using CookBook.DAL.Factories;
-using CookBook.DAL.Seeds;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
 using Xunit.Abstractions;

--- a/src/CookBook/CookBook.DAL.Tests/DbContextRecipeTests.cs
+++ b/src/CookBook/CookBook.DAL.Tests/DbContextRecipeTests.cs
@@ -1,13 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices.ComTypes;
-using System.Text;
 using System.Threading.Tasks;
 using CookBook.Common.Enums;
 using CookBook.Common.Tests;
+using CookBook.Common.Tests.Seeds;
 using CookBook.DAL.Entities;
-using CookBook.DAL.Seeds;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
 using Xunit.Abstractions;

--- a/src/CookBook/CookBook.DAL.Tests/DbContextTestsBase.cs
+++ b/src/CookBook/CookBook.DAL.Tests/DbContextTestsBase.cs
@@ -16,8 +16,9 @@ public class  DbContextTestsBase : IAsyncLifetime
         XUnitTestOutputConverter converter = new(output);
         Console.SetOut(converter);
         
-        DbContextFactory = new DbContextTestingInMemoryFactory(GetType().Name, seedTestingData: true);
+        // DbContextFactory = new DbContextTestingInMemoryFactory(GetType().Name, seedTestingData: true);
         // DbContextFactory = new DbContextLocalDBTestingFactory(GetType().FullName!, seedTestingData: true);
+        DbContextFactory = new DbContextSQLiteTestingFactory(GetType().FullName!, seedTestingData: true);
         
         CookBookDbContextSUT = DbContextFactory.CreateDbContext();
     }

--- a/src/CookBook/CookBook.DAL.Tests/DbContextTestsBase.cs
+++ b/src/CookBook/CookBook.DAL.Tests/DbContextTestsBase.cs
@@ -16,7 +16,7 @@ public class  DbContextTestsBase : IAsyncLifetime
         XUnitTestOutputConverter converter = new(output);
         Console.SetOut(converter);
         
-        DbContextFactory = new DbContextInMemoryFactory(GetType().Name, seedTestingData: true);
+        DbContextFactory = new DbContextTestingInMemoryFactory(GetType().Name, seedTestingData: true);
         // DbContextFactory = new DbContextLocalDBTestingFactory(GetType().FullName!, seedTestingData: true);
         
         CookBookDbContextSUT = DbContextFactory.CreateDbContext();
@@ -28,6 +28,7 @@ public class  DbContextTestsBase : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
+        await CookBookDbContextSUT.Database.EnsureDeletedAsync();
         await CookBookDbContextSUT.Database.EnsureCreatedAsync();
     }
 

--- a/src/CookBook/CookBook.DAL/CookBook.DAL.csproj
+++ b/src/CookBook/CookBook.DAL/CookBook.DAL.csproj
@@ -14,7 +14,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/CookBook/CookBook.DAL/CookBookDbContext.cs
+++ b/src/CookBook/CookBook.DAL/CookBookDbContext.cs
@@ -6,12 +6,12 @@ namespace CookBook.DAL
 {
     public class CookBookDbContext : DbContext
     {
-        private readonly bool _seedTestingData;
+        private readonly bool _seedDemoData;
 
-        public CookBookDbContext(DbContextOptions contextOptions, bool seedTestingData = false)
+        public CookBookDbContext(DbContextOptions contextOptions, bool seedDemoData = false)
             : base(contextOptions)
         {
-            _seedTestingData = seedTestingData;
+            _seedDemoData = seedDemoData;
         }
 
         public DbSet<IngredientAmountEntity> IngredientAmountEntities => Set<IngredientAmountEntity>();
@@ -20,6 +20,8 @@ namespace CookBook.DAL
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
+            base.OnModelCreating(modelBuilder);
+            
             modelBuilder.Entity<RecipeEntity>()
                 .HasMany(i => i.Ingredients)
                 .WithOne(i => i.Recipe)
@@ -30,14 +32,12 @@ namespace CookBook.DAL
                 .WithOne(i => i.Ingredient)
                 .OnDelete(DeleteBehavior.Restrict);
 
-            if (_seedTestingData)
+            if (_seedDemoData)
             {
                 IngredientSeeds.Seed(modelBuilder);
                 RecipeSeeds.Seed(modelBuilder);
                 IngredientAmountSeeds.Seed(modelBuilder);
             }
-
-            base.OnModelCreating(modelBuilder);
         }
     }
 }

--- a/src/CookBook/CookBook.DAL/Factories/SqlServerDbContextFactory.cs
+++ b/src/CookBook/CookBook.DAL/Factories/SqlServerDbContextFactory.cs
@@ -5,12 +5,12 @@ namespace CookBook.DAL.Factories
     public class SqlServerDbContextFactory : IDbContextFactory<CookBookDbContext>
     {
         private readonly string _connectionString;
-        private readonly bool _seedTestingData;
+        private readonly bool _seedDemoData;
 
-        public SqlServerDbContextFactory(string connectionString, bool seedTestingData = false)
+        public SqlServerDbContextFactory(string connectionString, bool seedDemoData = false)
         {
             _connectionString = connectionString;
-            _seedTestingData = seedTestingData;
+            _seedDemoData = seedDemoData;
         }
 
         public CookBookDbContext CreateDbContext()
@@ -21,7 +21,7 @@ namespace CookBook.DAL.Factories
             //optionsBuilder.LogTo(System.Console.WriteLine); //Enable in case you want to see tests details, enabled may cause some inconsistencies in tests
             //optionsBuilder.EnableSensitiveDataLogging();
 
-            return new CookBookDbContext(optionsBuilder.Options, _seedTestingData);
+            return new CookBookDbContext(optionsBuilder.Options, _seedDemoData);
         }
     }
 }

--- a/src/CookBook/CookBook.DAL/Seeds/IngredientAmountSeeds.cs
+++ b/src/CookBook/CookBook.DAL/Seeds/IngredientAmountSeeds.cs
@@ -7,50 +7,33 @@ namespace CookBook.DAL.Seeds;
 
 public static class IngredientAmountSeeds
 {
-    public static readonly IngredientAmountEntity EmptyIngredientAmountEntity = new(
-        Id: default, 
-        Amount: default,
-        Unit: default,
-        RecipeId: default, 
-        IngredientId: default)
-    {
-        Recipe = default,
-        Ingredient = default
-    };
-    
-    public static readonly IngredientAmountEntity IngredientAmountEntity1 = new(
+    public static readonly IngredientAmountEntity LemonadeLemon = new(
         Id: Guid.Parse(input: "0d4fa150-ad80-4d46-a511-4c666166ec5e"),
-        Amount: 1.0,
-        Unit: Unit.Kg,
-        RecipeId: RecipeSeeds.RecipeEntity.Id,
-        IngredientId: IngredientSeeds.IngredientEntity1.Id)
+        Amount: 250,
+        Unit: Unit.Ml,
+        RecipeId: RecipeSeeds.LemonadeRecipe.Id,
+        IngredientId: IngredientSeeds.Lemon.Id)
     {
-        Recipe = RecipeSeeds.RecipeEntity,
-        Ingredient = IngredientSeeds.IngredientEntity1
+        Recipe = RecipeSeeds.LemonadeRecipe,
+        Ingredient = IngredientSeeds.Lemon
     };
 
-    public static readonly IngredientAmountEntity IngredientAmountEntity2 = new(
+    public static readonly IngredientAmountEntity LemonadeWater = new(
         Id: Guid.Parse(input: "87833e66-05ba-4d6b-900b-fe5ace88dbd8"),
         Amount: 2.0,
         Unit: Unit.L,
-        RecipeId: RecipeSeeds.RecipeEntity.Id,
-        IngredientId: IngredientSeeds.IngredientEntity2.Id)
+        RecipeId: RecipeSeeds.LemonadeRecipe.Id,
+        IngredientId: IngredientSeeds.Water.Id)
     {
-        Recipe = RecipeSeeds.RecipeEntity,
-        Ingredient = IngredientSeeds.IngredientEntity2
+        Recipe = RecipeSeeds.LemonadeRecipe,
+        Ingredient = IngredientSeeds.Water
     };
-
-    //To ensure that no tests reuse these clones for non-idempotent operations
-    public static readonly IngredientAmountEntity IngredientAmountEntityUpdate = IngredientAmountEntity1 with { Id = Guid.Parse("A2E6849D-A158-4436-980C-7FC26B60C674"), Ingredient = null, Recipe = null, RecipeId = RecipeSeeds.RecipeForIngredientAmountEntityUpdate.Id};
-    public static readonly IngredientAmountEntity IngredientAmountEntityDelete = IngredientAmountEntity1 with { Id = Guid.Parse("30872EFF-CED4-4F2B-89DB-0EE83A74D279"), Ingredient = null, Recipe = null, RecipeId = RecipeSeeds.RecipeForIngredientAmountEntityDelete.Id };
 
     public static void Seed(this ModelBuilder modelBuilder)
     {
         modelBuilder.Entity<IngredientAmountEntity>().HasData(
-            IngredientAmountEntity1 with { Recipe = null, Ingredient = null },
-            IngredientAmountEntity2 with { Recipe = null, Ingredient = null },
-            IngredientAmountEntityUpdate,
-            IngredientAmountEntityDelete
+            LemonadeLemon with { Recipe = null, Ingredient = null },
+            LemonadeWater with { Recipe = null, Ingredient = null }
         );
     }
 }

--- a/src/CookBook/CookBook.DAL/Seeds/IngredientSeeds.cs
+++ b/src/CookBook/CookBook.DAL/Seeds/IngredientSeeds.cs
@@ -6,41 +6,24 @@ namespace CookBook.DAL.Seeds;
 
 public static class IngredientSeeds
 {
-    public static readonly IngredientEntity EmptyIngredient = new(
-        Id: default,
-        Name: default!,
-        Description: default!,
-        ImageUrl: default!);
-    
     public static readonly IngredientEntity Water = new(
         Id: Guid.Parse(input: "06a8a2cf-ea03-4095-a3e4-aa0291fe9c75"),
         Name: "Water",
         Description: "Mineral water",
-        ImageUrl: "https://www.pngitem.com/pimgs/m/40-406527_cartoon-glass-of-water-png-glass-of-water.png");
+        ImageUrl: @"https://www.pngitem.com/pimgs/m/40-406527_cartoon-glass-of-water-png-glass-of-water.png");
 
-    //To ensure that no tests reuse these clones for non-idempotent operations
-    public static readonly IngredientEntity WaterUpdate = Water with { Id = Guid.Parse("143332B9-080E-4953-AEA5-BEF64679B052") };
-    public static readonly IngredientEntity WaterDelete = Water with { Id = Guid.Parse("274D0CC9-A948-4818-AADB-A8B4C0506619") };
-
-    public static IngredientEntity IngredientEntity1 = new(
+    public static readonly IngredientEntity Lemon = new(
         Id: Guid.Parse(input: "df935095-8709-4040-a2bb-b6f97cb416dc"),
-        Name: "Ingredient seeded ingredient 1",
-        Description: "Ingredient seeded ingredient 1 description",
-        ImageUrl: null);
+        Name: "Lemon",
+        Description: "Yellow lemon",
+        ImageUrl: @"https://www.eatthis.com/wp-content/uploads/sites/4/2020/02/lemons.jpg?quality=82&strip=1&resize=640%2C360");
 
-    public static IngredientEntity IngredientEntity2 = new(
-        Id: Guid.Parse(input: "23b3902d-7d4f-4213-9cf0-112348f56238"),
-        Name: "Ingredient seeded ingredient 2",
-        Description: "Ingredient seeded ingredient 2 description",
-        ImageUrl: null);
 
     public static void Seed(this ModelBuilder modelBuilder)
     {
         modelBuilder.Entity<IngredientEntity>().HasData(
-            IngredientEntity1,
-            IngredientEntity2,
-            Water,
-            WaterUpdate,
-            WaterDelete);
+            Lemon,
+            Water
+        );
     }
 }

--- a/src/CookBook/CookBook.DAL/Seeds/RecipeSeeds.cs
+++ b/src/CookBook/CookBook.DAL/Seeds/RecipeSeeds.cs
@@ -7,46 +7,24 @@ namespace CookBook.DAL.Seeds;
 
 public static class RecipeSeeds
 {
-    public static readonly RecipeEntity EmptyRecipeEntity = new(
-        Id: default, 
-        Name: default!,
-        Description: default!,
-        Duration: default,
-        FoodType: default,
-        ImageUrl: default);
-    
-    public static readonly RecipeEntity RecipeEntity = new(
+    public static readonly RecipeEntity LemonadeRecipe = new(
         Id: Guid.Parse(input: "fabde0cd-eefe-443f-baf6-3d96cc2cbf2e"),
-        Name: "Recipe seeded recipe 1",
-        Description: "Recipe seeded recipe 1 description",
-        Duration: TimeSpan.FromHours(value: 2),
-        FoodType: FoodType.MainDish,
-        ImageUrl: null);
-
-    //To ensure that no tests reuse these clones for non-idempotent operations
-    public static readonly RecipeEntity RecipeEntityWithNoIngredients = RecipeEntity with { Id = Guid.Parse("98B7F7B6-0F51-43B3-B8C0-B5FCFFF6DC2E"), Ingredients = Array.Empty<IngredientAmountEntity>() };
-    public static readonly RecipeEntity RecipeEntityUpdate = RecipeEntity with { Id = Guid.Parse("0953F3CE-7B1A-48C1-9796-D2BAC7F67868"), Ingredients = Array.Empty<IngredientAmountEntity>() };
-    public static readonly RecipeEntity RecipeEntityDelete = RecipeEntity with { Id = Guid.Parse("5DCA4CEA-B8A8-4C86-A0B3-FFB78FBA1A09"), Ingredients = Array.Empty<IngredientAmountEntity>() };
-
-    public static readonly RecipeEntity RecipeForIngredientAmountEntityUpdate = RecipeEntity with { Id = Guid.Parse("4FD824C0-A7D1-48BA-8E7C-4F136CF8BF31"), Ingredients = Array.Empty<IngredientAmountEntity>() };
-    public static readonly RecipeEntity RecipeForIngredientAmountEntityDelete = RecipeEntity with { Id = Guid.Parse("F78ED923-E094-4016-9045-3F5BB7F2EB88"), Ingredients = Array.Empty<IngredientAmountEntity>() };
-
+        Name: "Lemonade",
+        Description: "Sweet summer lemonade",
+        Duration: TimeSpan.FromMinutes(value: 2.5),
+        FoodType: FoodType.Drink,
+        ImageUrl: @"https://www.thespruceeats.com/thmb/bOkzNHNuzGEH2UUAbmFBtTwAy6M=/2539x2539/smart/filters:no_upscale()/homemade-lemonade-2216227-hero-02copy-767d28c1e7cf468db2282d77103d0bf4.jpg");
 
     static RecipeSeeds()
     {
-        RecipeEntity.Ingredients.Add(IngredientAmountSeeds.IngredientAmountEntity1);
-        RecipeEntity.Ingredients.Add(IngredientAmountSeeds.IngredientAmountEntity2);
+        LemonadeRecipe.Ingredients.Add(IngredientAmountSeeds.LemonadeLemon);
+        LemonadeRecipe.Ingredients.Add(IngredientAmountSeeds.LemonadeWater);
     }
 
     public static void Seed(this ModelBuilder modelBuilder)
     {
         modelBuilder.Entity<RecipeEntity>().HasData(
-            RecipeEntity with { Ingredients = Array.Empty<IngredientAmountEntity>() },
-            RecipeEntityWithNoIngredients,
-            RecipeEntityUpdate,
-            RecipeEntityDelete,
-            RecipeForIngredientAmountEntityUpdate,
-            RecipeForIngredientAmountEntityDelete
+            LemonadeRecipe with { Ingredients = Array.Empty<IngredientAmountEntity>() }
         );
     }
 }


### PR DESCRIPTION
InMemory DB nepodporuje cascade delete na FK ... SQLite je rozumny zpusob jak v testech overit spravne nastaveni DB schematu.

Stavi nad  #47 tak pripadny merge az po(rebase).