### PR TITLE
Fix example console app comments

### DIFF
--- a/src/Exercise-01-ConsoleApp/ConsoleApp/CodeDemonstrations.cs
+++ b/src/Exercise-01-ConsoleApp/ConsoleApp/CodeDemonstrations.cs
@@ -19,7 +19,7 @@ internal static class CodeDemonstrations
     }
 
     /// <summary>
-    ///     Runs for loop, note: has to be static if we want to call it from Main
+    ///     Runs for loop, note: has to be static if we want to call it from Main.
     /// </summary>
     public static void RunForLoop()
     {
@@ -30,7 +30,7 @@ internal static class CodeDemonstrations
     }
 
     /// <summary>
-    ///     Runs while loop, note: has to be static if we want to call it from Main
+    ///     Runs while loop, note: has to be static if we want to call it from Main.
     /// </summary>
     public static void RunWhileLoop()
     {
@@ -44,7 +44,7 @@ internal static class CodeDemonstrations
     }
 
     /// <summary>
-    ///     Shows if branching, note: has to be static if we want to call it from Main
+    ///     Shows if branching, note: has to be static if we want to call it from Main.
     /// </summary>
     public static void ShowIf(int condition)
     {
@@ -61,8 +61,8 @@ internal static class CodeDemonstrations
 
     /// <summary>
     ///     Calculates basic mathematical operations (+,-,*,/) on given operands using
-    ///     mathematical assembly implemented by students them selves.
-    ///     Writes results on console.
+    ///     mathematical assembly implemented by students themselves.
+    ///     Writes the result to console.
     /// </summary>
     public static void Calculate()
     {
@@ -73,7 +73,7 @@ internal static class CodeDemonstrations
     }
 
     /// <summary>
-    ///     Gets input from keyboard, note: has to be static if we want to call it from Main
+    ///     Gets input from keyboard, note: has to be static if we want to call it from Main.
     /// </summary>
     public static void GetInput()
     {
@@ -90,12 +90,12 @@ internal static class CodeDemonstrations
         catch (Exception exception)
         {
             Console.WriteLine(exception.Message);
-            throw new ApplicationException("HUpsss....");
+            throw new ApplicationException("Upsss....");
         }
         finally
         {
             // executes always, after the try and/or catch
-            Console.WriteLine("Release resources... cleaning after my self");
+            Console.WriteLine("Release resources... cleaning after myself");
         }
     }
 }

--- a/src/Exercise-01-ConsoleApp/ConsoleApp/Program.cs
+++ b/src/Exercise-01-ConsoleApp/ConsoleApp/Program.cs
@@ -5,10 +5,9 @@ namespace Exercise_01.ConsoleApp
     internal static class Program
     {
         /// <summary>
-        ///     function Main - has to be static, has to have a name "Main", doesn't have to return a value
-        ///     - cannot call non-static methods
+        ///     Method Main - has to be static, has to have a name "Main", doesn't have to return a value.
         /// </summary>
-        /// <param name="args">array of strings which represents parameters of the program</param>
+        /// <param name="args">Array of strings which represents parameters of the program.</param>
         private static void Main(string[] args)
         {
             CodeDemonstrations.RunAllDemonstrations();
@@ -18,8 +17,8 @@ namespace Exercise_01.ConsoleApp
         }
 
         /// <summary>
-        ///     Helper - waits for any key to be pressed on a keyboard
-        ///     Holds the command prompt opened before program exits.
+        ///     Helper - waits for any key to be pressed on a keyboard.
+        ///     Holds the command prompt open before program exits.
         /// </summary>
         private static void WaitForPressedKey()
         {


### PR DESCRIPTION
- Fixed minor grammar errors and inconsistencies
- Fixed inaccurate information
  - Functions in C# are always referred to as *methods*, even when static
  - You **can** call non-static methods from `Main` (given an instance)
    - I deleted this for now, consider readding it rephrased