### PR TITLE
Fix email link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ winget install JetBrains.ReSharper
 * [Roman Jašek](https://www.linkedin.com/in/roman-jasek-16921839)
 * [Tibor Jašek](https://www.linkedin.com/in/tibor-jašek-717a5761)
 * [Michal Mrnuštík](https://www.linkedin.com/in/michal-mrnušt%C3%ADk-31050b60/)
-* [Michal Tichý](edu@tichymichal.net)
+* [Michal Tichý](mailto:edu@tichymichal.net)
 * [Jan Pluskal](https://www.fit.vut.cz/person/ipluskal)
 * [Michal Koutenský](https://www.fit.vut.cz/person/koutenmi)
 * [Daniel Dolejška](https://www.fit.vut.cz/person/dolejska)


### PR DESCRIPTION
Added a `mailto:` prefix to a link which previously resolved to "https://github.com/nesfit/ICS/blob/master/edu@tichymichal.net"