### PR TITLE
DeepAssert.Contains()

### DIFF
--- a/src/CookBook/CookBook.Common.Tests/DeepAssert.cs
+++ b/src/CookBook/CookBook.Common.Tests/DeepAssert.cs
@@ -1,4 +1,5 @@
 ﻿using KellermanSoftware.CompareNetObjects;
+using Xunit.Sdk;
 
 namespace CookBook.Common.Tests;
 
@@ -24,4 +25,27 @@ public static class DeepAssert
             throw new ObjectEqualException(expected!, actual!, comparisonResult.DifferencesString);
         }
     }
+
+    public static void Contains<T>(T? expected, IEnumerable<T>? collection, params string[] propertiesToIgnore)
+        {
+            if (collection is null)
+                throw new ArgumentNullException(nameof(collection));
+
+            CompareLogic compareLogic = new()
+            {
+                Config =
+                {
+                    MembersToIgnore = propertiesToIgnore.ToList(),
+                    IgnoreCollectionOrder = true,
+                    IgnoreObjectTypes = true,
+                    CompareStaticProperties = false,
+                    CompareStaticFields = false
+                }
+            };
+
+            if (!collection.Any(item => compareLogic.Compare(expected!, item).AreEqual))
+            {
+                throw new ContainsException(expected!, collection);
+            }
+        }
 }

--- a/src/CookBook/CookBook.DAL.Tests/DbContextRecipeTests.cs
+++ b/src/CookBook/CookBook.DAL.Tests/DbContextRecipeTests.cs
@@ -125,6 +125,17 @@ public class DbContextRecipeTests : DbContextTestsBase
     }
 
     [Fact]
+    public async Task GetAll_Recipes_ContainsSeededRecipe()
+    {
+        //Act
+        var entities = await CookBookDbContextSUT.Recipes.ToListAsync();
+
+        //Assert
+        DeepAssert.Contains(RecipeSeeds.RecipeEntity, entities,
+            nameof(RecipeEntity.Ingredients));
+    }
+
+    [Fact]
     public async Task GetById_Recipe()
     {
         //Act


### PR DESCRIPTION
Metoda `DeepAssert.Contains()` umožňuje hledat v seznamu složitější entity, které obsahují např. kolekce, a není tudíž možné použít `Assert.Contains()`.