### PR TITLE
fix(DeepAssert): throw created exception

### DIFF
--- a/src/CookBook/CookBook.Common.Tests/DeepAssert.cs
+++ b/src/CookBook/CookBook.Common.Tests/DeepAssert.cs
@@ -22,7 +22,7 @@ public static class DeepAssert
         ComparisonResult comparisonResult = compareLogic.Compare(expected!, actual!);
         if (!comparisonResult.AreEqual)
         {
-            EqualException.ForMismatchedValues(expected, actual, comparisonResult.DifferencesString);
+            throw EqualException.ForMismatchedValues(expected, actual, comparisonResult.DifferencesString);
         }
     }
 
@@ -45,7 +45,7 @@ public static class DeepAssert
 
             if (!collection.Any(item => compareLogic.Compare(expected!, item).AreEqual))
             {
-                ContainsException.ForCollectionItemNotFound(expected.ToString(), nameof(collection));
+                throw ContainsException.ForCollectionItemNotFound(expected.ToString(), nameof(collection));
             }
         }
 }


### PR DESCRIPTION
Both methods in DeepAssert are supposed to throw an exception if the comparison fails. The exception is created using a static method `EqualException.ForMismatchedValues(...)`, but is never thrown, resulting in the compare always being successful.

Fix is to throw the created exception.

This bug was introduced here: https://github.com/nesfit/ICS/commit/d5ccaae30b9a4afec17e8684cff30b2a7437ac0f#diff-da32ce4258864d0aac1bd9a578460295a867a3637ff3dacb4a5865e8de82bc4e